### PR TITLE
Update the layout after creation

### DIFF
--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -50,6 +50,7 @@ DisplayManager::DisplayManager(ConfigPtr config, bool systemBus)
     createLayers();
 
     mEvents.reset(new EventHandler(mObjects, mActions));
+    mObjects.update();
 }
 
 DisplayManager::~DisplayManager()

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -95,6 +95,7 @@ void EventHandler::objectNotification(ilmObjectType object, t_ilm_uint id,
                 }
 
                 mActions.createSurface(id);
+                mObjects.update();
             }
             else {
                 mActions.deleteSurface(id);
@@ -112,6 +113,7 @@ void EventHandler::objectNotification(ilmObjectType object, t_ilm_uint id,
                 }
 
                 mActions.createLayer(id);
+                mObjects.update();
             }
             else {
                 mActions.deleteLayer(id);

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -150,6 +150,10 @@ void EventHandler::surfaceNotification(t_ilm_surface id,
 
         if (surface) {
             surface->surfaceNotification(properties, mask);
+            LOG(mLog, ERROR) << "Surface ID= "<<id <<" is found.";
+        }
+        else {
+            LOG(mLog, ERROR) << "Surface ID= "<<id <<" is NOT found.";
         }
     }
     catch (const exception& e) {


### PR DESCRIPTION
The was an issue: dependency between a display and layer is broken if
Layer has been modified. The solution: re-assign the layer to display.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>